### PR TITLE
#2: default `parseError` fn doesn't work (closes #2)

### DIFF
--- a/src/HTTPAPI.js
+++ b/src/HTTPAPI.js
@@ -36,13 +36,13 @@ export default function HTTPAPI({
   parseError = err => {
     const { errors = [] } = (() => {
       try {
-        return JSON.parse(err.data);
+        return JSON.parse(err.response.data);
       } catch (e) {
         return {};
       }
     })();
 
-    return { status: err.status, errors };
+    return { status: err.response.status, errors };
   }
 
 }) {


### PR DESCRIPTION
Issue #2

## Test Plan

### tests performed
error modal works properly in QIA