### PR TITLE
#18: warn when passing data (body) to an api but no metarpheus typing is available for it (closes #18)

### DIFF
--- a/src/HTTPAPI.js
+++ b/src/HTTPAPI.js
@@ -75,7 +75,7 @@ export default function HTTPAPI({
       impl: ({
         token = null,
         params: urlParams = [],
-        data = {},
+        data,
         query: queryParams = {}
       } = {}) => {
         if (process.env.NODE_ENV !== 'production') {
@@ -96,16 +96,22 @@ export default function HTTPAPI({
           });
         }
 
-        if (process.env.NODE_ENV !== 'production' && bodyParamType) {
-          t.assert(
-            bodyParamType(data),
-            `HTTPAPI: Invalid \`data\` (body) provided to ${methodName}`
-          );
-        }
-
         const url = `${apiEndpoint}/${route(
           ...urlParams/*.map(stringifyParam)*/.map(encodeURIComponent)
         )}`;
+
+        if (process.env.NODE_ENV !== 'production' && bodyParamType) {
+          t.assert(
+            bodyParamType(data),
+            `HTTPAPI: Invalid \`data\` (body) provided for ${method} ${url}`
+          );
+        }
+
+        if (process.env.NODE_ENV !== 'production' && data && !bodyParamType) {
+          warn(
+            `Passing data (body) to ${method} ${url} but metarpheus doesn't specify a body type`
+          );
+        }
 
         const headers = {};
 

--- a/test/HTTPAPI.test.js
+++ b/test/HTTPAPI.test.js
@@ -51,7 +51,17 @@ describe('HTTPAPI', () => {
   });
 
   it('should throw if invoked with malformed/missing data (body)', () => {
-    expect(() => getApi().fooController_addFoos2({})).toThrow();
+    expect(() => getApi().fooController_addFoos({})).toThrow();
+  });
+
+  it('should log a warning if passing data (body) to an api with untyped data', () => {
+    return expectToWarn(
+      () => {
+        getApi().fooController_addFoos2({ token: 'token', data: { foo: 'bar' } }).catch(() => {});
+        return Promise.resolve();
+      },
+      'HTTPAPI: Passing data (body) to post http://www.example.com/foos2 but metarpheus doesn\'t specify a body type' // eslint-disable-line max-len
+    );
   });
 
   it('should fail if api returns an incorrect response', () => {
@@ -97,13 +107,13 @@ describe('HTTPAPI', () => {
         'Content-Type': 'application/json'
       }
     }).post('/foos').reply(200, { data: {} });
-    return getApi().fooController_addFoos({ token: 'asd', data: {} });
+    return getApi().fooController_addFoos({ token: 'asd', data: { foo: 'bar' } });
   });
 
   xit('should warn if api returns non-gzipped content', () => {
     nock(apiEndpoint).post('/foos').reply(200, { data: {} });
     return expectToWarn(
-      () => getApi().fooController_addFoos({ token: 'asd', data: {} }),
+      () => getApi().fooController_addFoos({ token: 'asd', data: { foo: 'bar' } }),
       'asd'
     );
   });

--- a/test/apiRoutes.js
+++ b/test/apiRoutes.js
@@ -35,7 +35,8 @@ export default [
     authenticated: true,
     returnType: t.Any,
     route: (...routeParams) => ['foos'].join('/'),
-    params: {}
+    params: {},
+    body: t.struct({ foo: t.String })
   },
   {
     method: 'post',
@@ -43,7 +44,6 @@ export default [
     authenticated: true,
     returnType: t.Any,
     route: (...routeParams) => ['foos2'].join('/'),
-    params: {},
-    body: t.struct({ foo: t.String })
+    params: {}
   },
 ];


### PR DESCRIPTION
Issue #18

## Test Plan

### tests performed

See unit test
Also tested manually on qia where there were indeed a few warnings

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
